### PR TITLE
Add Calibri substitute font Carlito

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,8 @@ RUN apk add libreoffice \
 	build-base \ 
 	# Install fonts
 	msttcorefonts-installer fontconfig && \
+	# Install Calibri substitute from edge
+	apk add font-crosextra-carlito --repository=http://dl-cdn.alpinelinux.org/alpine/edge/testing && \
     update-ms-fonts && \
     fc-cache -f
 


### PR DESCRIPTION
Most new Word documents now use Calibri, so it would be really useful if this substitute font (Carlito) was added. The default substitute font is way too big.

You can use this example file:
[calibri test.docx](https://github.com/as-a-service/pdf/files/6822375/calibri.test.docx) and compare how it looks on the service and on a local build of this branch. 
https://pdf.as-a-service.dev/?url=https://github.com/as-a-service/pdf/files/6822375/calibri.test.docx